### PR TITLE
chore: permissions test (draft)

### DIFF
--- a/tools/gh-perms-test.txt
+++ b/tools/gh-perms-test.txt
@@ -1,0 +1,4 @@
+GitHub permissions test file (safe to delete).
+Created by Codex CLI to verify PR and release permissions.
+Timestamp (UTC): 2025-09-03T21:13:21Z
+


### PR DESCRIPTION
This is an automated, temporary PR to verify `gh` permissions.

- Adds `tools/gh-perms-test.txt` (safe to delete)
- Opened as draft and will be closed automatically.

No functional changes.