### PR TITLE
chore: Dockerfile + docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Minimal Dockerfile for Soulfield API (Node backend)
+FROM node:20-alpine AS base
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY package.json package-lock.json ./
+RUN npm ci --only=production
+
+# Copy source
+COPY . .
+
+# Expose API and MCP ports
+EXPOSE 8790 8791
+
+# Default command runs the API server. Use compose to run MCP.
+CMD ["node", "backend/index.cjs"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+services:
+  api:
+    build: .
+    image: soulfield-api:local
+    env_file:
+      - .env
+    environment:
+      # Allow offline runs if keys aren’t set
+      - DEV_NO_API=${DEV_NO_API:-1}
+      - PORT=8790
+    ports:
+      - "8790:8790"
+    command: ["node", "backend/index.cjs"]
+    restart: unless-stopped
+
+  mcp:
+    build: .
+    image: soulfield-api:local
+    depends_on:
+      - api
+    ports:
+      - "8791:8791"
+    command: ["node", "backend/mcp-server.cjs"]
+    restart: unless-stopped
+


### PR DESCRIPTION
Adds Dockerfile (Node 20) and docker-compose with services for API (8790) and MCP (8791).
Uses .dockerignore and supports DEV_NO_API=1 for offline runs.